### PR TITLE
Removes logfile deletion in the absence of an index file.

### DIFF
--- a/electron/filesystem.ts
+++ b/electron/filesystem.ts
@@ -119,7 +119,6 @@ export function fixLogs(character: string): void {
         const fd = fs.openSync(full, 'r+');
         const indexPath = path.join(dir, `${file}.idx`);
         if(!fs.existsSync(indexPath)) {
-            fs.unlinkSync(full);
             continue;
         }
         const indexFd = fs.openSync(indexPath, 'r+');


### PR DESCRIPTION
To fully regenerate an index file, two things need to happen:
* The logs need to exist and be complete.
* The index's header needs to be legible.

In the absence of an existing index file, the relevant log file should not be deleted and the log tool should skip that file for now. If the user is specifically concerned about that channel, chances are they'll access it (which will generate a blank index that can be used in the next repair attempt).

The log file is valuable. Deleting it because an easily-constructed companion is missing is a poor sequence of events, especially given that most normal f-chat interactions don't depend on the index. In the absence of an index file, chatting and saving the logs still functions completely fine, as does loading the last 20 posts.